### PR TITLE
Add player deletion functionality

### DIFF
--- a/TennisScores.API/Controllers/PlayersController.cs
+++ b/TennisScores.API/Controllers/PlayersController.cs
@@ -51,4 +51,12 @@ public class PlayersController : ControllerBase
         var players = await _playerService.SearchPlayersByNamePatternAsync(name);
         return Ok(players);
     }
+
+    [HttpDelete]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    public async Task<ActionResult> DeletePlayers(Guid id)
+    {
+        var res = await _playerService.DeletePlayer(id);
+        return Ok(res);
+    }
 }

--- a/TennisScores.API/Services/IPlayerServices.cs
+++ b/TennisScores.API/Services/IPlayerServices.cs
@@ -12,4 +12,5 @@ public interface IPlayerService
     Task<PlayerLightDto?> GetByIdAsync(Guid id);
     Task<IEnumerable<PlayerLightDto>> GetAllAsync();
     Task<IEnumerable<PlayerLightDto>> SearchPlayersByNamePatternAsync(string name);
+    Task<bool> DeletePlayer(Guid id);
 }

--- a/TennisScores.API/Services/PlayerService.cs
+++ b/TennisScores.API/Services/PlayerService.cs
@@ -53,4 +53,16 @@ public class PlayerService : IPlayerService
     {
         return (await _playerRepository.SearchByNamePatternAsync(name)).Select(p => p.ToLightDto());
     }
+    public async Task<bool> DeletePlayer(Guid id)
+    {
+        var player = await _playerRepository.GetByIdAsync(id);
+
+        if (player != null)
+        {
+            _playerRepository.Remove(player);
+            await _unitOfWork.SaveChangesAsync();
+            return true;
+        }
+        else return false;
+    }
 }


### PR DESCRIPTION
Implemented a new HTTP DELETE endpoint in `PlayersController` to allow deletion of players by GUID. Updated `IPlayerService` to include a `DeletePlayer` method, and modified `PlayerService` to handle the deletion logic, returning a boolean indicating success or failure.