### PR TITLE
Improve open source contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible API or scoring problem
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+Describe the bug clearly.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Branch or version:
+- .NET version:
+- Database:
+- Docker or local run:
+
+## Logs or screenshots
+
+Paste relevant logs, API responses, or screenshots if available.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement for the API or scoring domain
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What user or contributor problem would this solve?
+
+## Proposed solution
+
+Describe the behavior you would like.
+
+## Alternatives considered
+
+List any alternatives or tradeoffs.
+
+## Additional context
+
+Add examples, API shapes, screenshots, or links if helpful.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,24 @@
+---
+name: Good first issue
+about: Template for small, well-scoped contributor tasks
+title: "[Good first issue]: "
+labels: good first issue
+assignees: ""
+---
+
+## Goal
+
+Describe the small outcome expected from this issue.
+
+## Suggested files
+
+List the likely files or areas to inspect.
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+
+## Hints
+
+Add context that helps a new contributor get started.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe what changed and why.
+
+## Testing
+
+- [ ] `dotnet test`
+- [ ] Manual API test, if relevant
+
+## Checklist
+
+- [ ] I kept the change focused.
+- [ ] I updated tests or documentation where needed.
+- [ ] I did not commit secrets or local configuration.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+## Our Pledge
+
+We want TennisScoresAPI to be a welcoming and useful project for contributors of different backgrounds and experience levels.
+
+Participants are expected to communicate with respect, assume good intent, and focus criticism on ideas, code, and project outcomes.
+
+## Unacceptable Behavior
+
+Unacceptable behavior includes harassment, insults, discriminatory language, personal attacks, publishing private information, or repeated disruption of project discussions.
+
+## Enforcement
+
+Project maintainers may remove comments, close issues, reject contributions, or block participants who do not follow this code of conduct.
+
+If you need to report a concern, open a private channel with the maintainer listed in the repository profile or contact the project owner through GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to TennisScoresAPI
+
+Thanks for your interest in contributing. TennisScoresAPI is the backend for an open-source live tennis scoring platform aimed at clubs, academies, associations, and amateur tournaments.
+
+## Before You Start
+
+- Check existing issues and pull requests to avoid duplicate work.
+- For larger changes, open an issue first so the design can be discussed.
+- Keep pull requests focused and reasonably small.
+
+## Local Setup
+
+Requirements:
+
+- .NET 10 SDK
+- Docker, if you want to run PostgreSQL or build images locally
+- PostgreSQL 15+ for integration scenarios
+
+Common commands:
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+dotnet run --project TennisScores.API/TennisScores.API.csproj
+```
+
+Swagger is available at `/swagger` when the API is running.
+
+## Tests
+
+Please add or update tests when changing scoring rules, API behavior, DTOs, persistence, or SignalR notifications.
+
+Run the full test suite before opening a pull request:
+
+```bash
+dotnet test
+```
+
+## Pull Request Guidelines
+
+- Explain the problem and the solution clearly.
+- Include screenshots or API examples when helpful.
+- Keep public DTO changes intentional and documented.
+- Update the WebApp client contract when API changes require it.
+- Do not commit secrets, production passwords, local `.env` files, or generated personal data.
+
+## Useful Contribution Areas
+
+- Tennis scoring edge cases: tie-breaks, super tie-breaks, completed matches, server rotation.
+- Scoring engine extraction and domain tests.
+- Health checks and production diagnostics.
+- OpenAPI documentation.
+- Developer onboarding and documentation.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # TennisScoresAPI
 
+[![Build, test and publish](https://github.com/1fini/TennisScoresAPI/actions/workflows/buildv2.yaml/badge.svg)](https://github.com/1fini/TennisScoresAPI/actions/workflows/buildv2.yaml)
+[![Docker image](https://img.shields.io/docker/v/1fini/tennisscoreapi/latest?label=dockerhub)](https://hub.docker.com/r/1fini/tennisscoreapi)
+[![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
+
 Backend API for live tennis scoring, tournament management, player management, and match lifecycle tracking.
 
 TennisScoresAPI powers the TennisScore MVP. It exposes REST endpoints for tournaments, players, matches, and live scoring, persists match state in PostgreSQL with Entity Framework Core, and broadcasts live match updates through SignalR.
+
+## Why This Project Exists
+
+TennisScore is an open-source live tennis scoring platform for clubs, academies, associations, and amateur tournaments. The goal is to make it simple to create tournaments, score matches courtside, and share live updates without relying on expensive or closed tournament software.
+
+This repository contains the API and domain logic. The Blazor WebApp lives in the companion repository:
+
+- https://github.com/1fini/TennisScoreWebApp
+
+## Demo
+
+The MVP is deployed at:
+
+- https://live.tennismentorsclub.fr
+
+The public demo can be protected by Basic Auth while the project is still in MVP mode. If you are interested in contributing and need access, open a GitHub issue.
 
 ## Features
 
@@ -99,6 +120,19 @@ Swagger UI is available when the API is running:
 ```text
 /swagger
 ```
+
+## Contributing
+
+Contributions are welcome. The most useful areas right now are:
+
+- tennis scoring edge cases and tests;
+- API design and OpenAPI contract improvements;
+- observability, health checks, and production hardening;
+- documentation and developer experience.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+
+Good first contributions are usually small tests, documentation fixes, or issues labeled `good first issue`.
 
 ## Database Migrations
 
@@ -210,6 +244,7 @@ Only the WebApp is exposed publicly. The API remains internal to Docker networki
 ## Roadmap
 
 - Extract a pure scoring engine from the application service layer.
+- Add undo support for the last scored point.
 - Add health check endpoints.
 - Harden Swagger exposure for production.
 - Add authentication for MVP users.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+The `main` branch is the only currently supported version.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for sensitive security problems.
+
+Report vulnerabilities privately through GitHub security advisories when available, or contact the repository owner through GitHub with:
+
+- a short description of the issue;
+- steps to reproduce;
+- potential impact;
+- any suggested mitigation.
+
+## Secrets
+
+Never commit production secrets, database passwords, Basic Auth hashes, private keys, tokens, or local `.env` files.
+
+Use environment variables, GitHub secrets, Docker secrets, or server-local configuration for sensitive values.


### PR DESCRIPTION
## Summary

- Add README badges, project positioning, demo link, contribution guidance, and roadmap entry.
- Add CONTRIBUTING, CODE_OF_CONDUCT, and SECURITY documents.
- Add bug report, feature request, good first issue, and pull request templates.

## Validation

- `dotnet build --configuration Release` passed locally.
- Documentation-only changes; no runtime code changed.