### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildv2.yaml
+++ b/.github/workflows/buildv2.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   DOCKER_IMAGE_NAME: 1fini/tennisscoreapi
   DOCKER_MIGRATIONS_IMAGE_NAME: 1fini/tennisscoreapi-migrations


### PR DESCRIPTION
Potential fix for [https://github.com/1fini/TennisScoresAPI/security/code-scanning/5](https://github.com/1fini/TennisScoresAPI/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/buildv2.yaml` so all jobs inherit minimal token access unless overridden.  
For this workflow, `contents: read` is sufficient as a baseline and supports `actions/checkout@v4` in both jobs. No functional behavior changes are required.

Best single change:
- In `.github/workflows/buildv2.yaml`, insert:
  - `permissions:`
  - `  contents: read`
- Place it near the top-level keys (e.g., after `on:` block and before `env:`) so it applies globally.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
